### PR TITLE
Get environment variable from airbrake settings dict - fix

### DIFF
--- a/airbrake/utils/client.py
+++ b/airbrake/utils/client.py
@@ -117,6 +117,6 @@ class Client(object):
 
         env_em = etree.SubElement(notice_em, 'server-environment')
 
-        etree.SubElement(env_em, 'environment-name').text = getattr(self.settings, 'ENVIRONMENT', 'development')
+        etree.SubElement(env_em, 'environment-name').text = self.settings.get('ENVIRONMENT', 'development')
 
         return '<?xml version="1.0" encoding="UTF-8"?>%s' % etree.tostring(notice_em)


### PR DESCRIPTION
Sorry. The  previous pull request #9 does not fix the problem. Please see a new one.