### PR TITLE
Use ssl by default

### DIFF
--- a/airbrake/utils/client.py
+++ b/airbrake/utils/client.py
@@ -16,7 +16,7 @@ class Client(object):
 
     DEFAULTS = {
         'TIMEOUT': 5,
-        'USE_SSL': False,
+        'USE_SSL': True,
     }
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-airbrake',
-    version='0.0.1',
+    version='0.0.2',
     description='A Django app for submitting exceptions to Airbrake.io.',
     long_description='',
     keywords='django, airbrake',


### PR DESCRIPTION
Be consistent with API documentation and use https by default.