### PR TITLE
Add support for Python 3 & Django 1.10

### DIFF
--- a/airbrake/middleware.py
+++ b/airbrake/middleware.py
@@ -1,10 +1,13 @@
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
+from django.utils.deprecation import MiddlewareMixin
 from airbrake.utils.client import Client
 
-class AirbrakeNotifierMiddleware(object):
-    def __init__(self):
+class AirbrakeNotifierMiddleware(MiddlewareMixin):
+    def __init__(self, *args, **kwargs):
         self.client = Client()
+
+        super(AirbrakeNotifierMiddleware, self).__init__(*args, **kwargs)
 
     def process_exception(self, request, exception):
         if hasattr(settings, 'AIRBRAKE') and not settings.AIRBRAKE.get('DISABLE', False):

--- a/airbrake/utils/client.py
+++ b/airbrake/utils/client.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.urlresolvers import resolve
 import sys
-import urllib2
+from six.moves import urllib
 import traceback
 from lxml import etree
 
@@ -22,10 +22,10 @@ class Client(object):
     @property
     def url(self):
         scheme = 'http'
-        if self.settings['USE_SSL']:
+        if self.settings.get('USE_SSL', False):
             scheme = 'https'
 
-        if self.settings['API_URL']:
+        if 'API_URL' in self.settings:
             url = self.settings['API_URL'] + '/notifier_api/v2/notices'
         else:
             url = Client.API_URL % scheme
@@ -47,8 +47,8 @@ class Client(object):
         }
 
         payload = self._generate_xml(exception=exception, request=request)
-        req = urllib2.Request(self.url, payload, headers)
-        resp = urllib2.urlopen(req, timeout=self.settings['TIMEOUT'])
+        req = urllib.request.Request(self.url, payload.encode('utf8'), headers)
+        resp = urllib.request.urlopen(req, timeout=self.settings['TIMEOUT'])
         status = resp.getcode()
 
         if status == 200:

--- a/airbrake/utils/client.py
+++ b/airbrake/utils/client.py
@@ -22,7 +22,7 @@ class Client(object):
     @property
     def url(self):
         scheme = 'http'
-        if self.settings.get('USE_SSL', False):
+        if self.settings.get('USE_SSL', True):
             scheme = 'https'
 
         if 'API_URL' in self.settings:

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/joestump/django-airbrake/
 
 Package: python-django-airbrake
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.5), python-django (>= 1.2.0), python-decorator
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.5), python-django (>= 1.2.0), python-decorator, six
 Description: Django application for integrating Airbrake.io into Django.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     zip_safe=False,
-    install_requires=['decorator', 'lxml'],
+    install_requires=['decorator', 'lxml', 'six'],
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
Replaces: #11

* added six, using six urllib to replace urllib2

Fixes the following failure when running django 1.10+ using python 3

```
File "/usr/local/lib/python3.6/site-packages/airbrake/utils/client.py", line 4, in <module>
    import urllib2
ModuleNotFoundError: No module named 'urllib2'
```
