### PR TITLE
Automatic error sending with debugged middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.pyc
 *.swp
 django_airbrake.egg-info
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.swp
 django_airbrake.egg-info
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *.swp
+django_airbrake.egg-info

--- a/README.mkd
+++ b/README.mkd
@@ -33,6 +33,15 @@ AIRBRAKE = {
 Then just restart your server!
 
 ### Automatically sending errors to airbrake
+
+##### New-style (introduced in Django 1.10):
+```python
+MIDDLEWARE = (
+    ...,
+    'airbrake.middleware.AirbrakeNotifierMiddleware'
+)
+```
+##### Old-style:
 ```python
 MIDDLEWARE_CLASSES = (
     ...,

--- a/README.mkd
+++ b/README.mkd
@@ -32,6 +32,14 @@ AIRBRAKE = {
 
 Then just restart your server!
 
+### Automatically sending errors to airbrake
+```python
+MIDDLEWARE_CLASSES = (
+    ...,
+    'airbrake.middleware.AirbrakeNotifierMiddleware'
+)
+```
+
 ### Manually sending errors to airbrake
 
 This example illustrates sending an error to Airbrake in a try catch.

--- a/airbrake/middleware.py
+++ b/airbrake/middleware.py
@@ -1,13 +1,10 @@
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
-from django.utils.deprecation import MiddlewareMixin
 from airbrake.utils.client import Client
 
-class AirbrakeNotifierMiddleware(MiddlewareMixin):
+class AirbrakeNotifierMiddleware(object):
     def __init__(self, *args, **kwargs):
         self.client = Client()
-
-        super(AirbrakeNotifierMiddleware, self).__init__(*args, **kwargs)
 
     def process_exception(self, request, exception):
         if hasattr(settings, 'AIRBRAKE') and not settings.AIRBRAKE.get('DISABLE', False):

--- a/airbrake/middleware.py
+++ b/airbrake/middleware.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 try:
-    # MiddlewareMixin is not available anymore in Django 1.8.7
+    # MiddlewareMixin is not available on older versions of Django
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
     MiddlewareMixin = object

--- a/airbrake/middleware.py
+++ b/airbrake/middleware.py
@@ -1,10 +1,17 @@
 from django.conf import settings
-from django.core.exceptions import MiddlewareNotUsed
+try:
+    # MiddlewareMixin is not available anymore in Django 1.8.7
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 from airbrake.utils.client import Client
 
-class AirbrakeNotifierMiddleware(object):
+
+class AirbrakeNotifierMiddleware(MiddlewareMixin):
     def __init__(self, *args, **kwargs):
         self.client = Client()
+
+        super(AirbrakeNotifierMiddleware, self).__init__(*args, **kwargs)
 
     def process_exception(self, request, exception):
         if hasattr(settings, 'AIRBRAKE') and not settings.AIRBRAKE.get('DISABLE', False):


### PR DESCRIPTION
The middleware was not working with Django 1.8.7, and was not documented in the Readme.