### PR TITLE
fix import for Django 2

### DIFF
--- a/airbrake/utils/client.py
+++ b/airbrake/utils/client.py
@@ -1,5 +1,8 @@
 from django.conf import settings
-from django.core.urlresolvers import resolve
+try:
+    from django.core.urlresolvers import resolve
+except ImportError
+    from django.urls import resolve
 import sys
 from six.moves import urllib
 import traceback


### PR DESCRIPTION
Hi, 
I just tried to run airbrake-django on a Django 2 project and it fails on this import. I'm sure you want to handle Django versioning on a more complete way (btw it would really help to state on the Readme what versions are tested), so feel free to close this PR in this case.

Best,
Markos