### PR TITLE
Add filter exceptions to prevent propagation to Airbrake

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -29,6 +29,7 @@ AIRBRAKE = {
     'API_KEY': 'YOUR_PROJECT_API_KEY',
     'TIMEOUT': 5,
     'ENVIRONMENT': 'production',
+    'FILTERED_EXCEPTIONS': (Http404,)
 }
 ```
 

--- a/airbrake/middleware.py
+++ b/airbrake/middleware.py
@@ -14,5 +14,7 @@ class AirbrakeNotifierMiddleware(MiddlewareMixin):
         super(AirbrakeNotifierMiddleware, self).__init__(*args, **kwargs)
 
     def process_exception(self, request, exception):
-        if hasattr(settings, 'AIRBRAKE') and not settings.AIRBRAKE.get('DISABLE', False):
+        if (hasattr(settings, 'AIRBRAKE') and
+                not settings.AIRBRAKE.get('DISABLE', False) and
+                not isinstance(exception, settings.AIRBRAKE.get('FILTERED_EXCEPTIONS', tuple()))):
             self.client.notify(exception=exception, request=request)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-airbrake',
-    version='0.0.2',
+    version='0.0.4',
     description='A Django app for submitting exceptions to Airbrake.io.',
     long_description='',
     keywords='django, airbrake',


### PR DESCRIPTION
This allows errors defined in Airbrake's Django settings to be ignored and prevented from propagating up to Airbrake.

Example:
```
# settings.py
from django.http import Http404

AIRBRAKE = {
    'API_KEY': 'XXXXXXX',
    'IGNORABLE_EXCEPTIONS': (Http404,)
}
```